### PR TITLE
fix: disable jaeger tracing out of the box

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,12 +55,12 @@
             <artifactId>micrometer-registry-prometheus</artifactId>
         </dependency>
 
-        <!-- Distributed tracing with OpenTracing -->
-        <dependency>
+        <!-- Distributed tracing with OpenTracing (uncomment to enable) -->
+       <!--  <dependency>
             <groupId>io.opentracing.contrib</groupId>
             <artifactId>opentracing-spring-jaeger-web-starter</artifactId>
             <version>${opentracing-spring-jaeger-web-starter.version}</version>
-        </dependency>
+        </dependency> -->
 
         <!-- Application -->
         <dependency>


### PR DESCRIPTION
Disabling Jaeger tracing out of the box for now to address https://snyk.io/vuln/SNYK-JAVA-ORGAPACHETHRIFT-1074898. The library has not been maintained for a few months. Users can uncomment to enable in their own apps.